### PR TITLE
Page now not reloaded after save

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -209,7 +209,6 @@ function save(notifyComplete) {
   return Fliplet.Widget.save(widgetData).then(function() {
     if (notifyComplete) {
       Fliplet.Widget.complete();
-      Fliplet.Studio.emit('reload-page-preview');
     } else {
       Fliplet.Studio.emit('reload-widget-instance', widgetId);
     }


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#5153

## Description
Removed page reload button.

## Screenshots/screencasts
![image demo](https://user-images.githubusercontent.com/52824207/68215554-1ddc8e80-ffe8-11e9-9bb0-966c19336b08.gif)

## Backward compatibility
This change is fully backward compatible.