### PR TITLE
Prevent click on save button while data is saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # IDE and OS files
 .DS_Store
 .idea
+.history

--- a/js/interface.js
+++ b/js/interface.js
@@ -65,11 +65,13 @@ function attahObservers() {
 
   // 1. Fired from Fliplet Studio when the external save button is clicked
   Fliplet.Widget.onSaveRequest(function() {
+    Fliplet.Widget.toggleSaveButton(false);
     if (linkActionProvider && !$('#pinch').is(':checked') && !$('#none').is(':checked')) {
       return linkActionProvider.forwardSaveRequest();
     } else {
       forwardSaveRequestFilePicker();
     }
+    Fliplet.Widget.complete();
   });
 }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -66,11 +66,13 @@ function attahObservers() {
   // 1. Fired from Fliplet Studio when the external save button is clicked
   Fliplet.Widget.onSaveRequest(function() {
     Fliplet.Widget.toggleSaveButton(false);
+
     if (linkActionProvider && !$('#pinch').is(':checked') && !$('#none').is(':checked')) {
       return linkActionProvider.forwardSaveRequest();
     } else {
       forwardSaveRequestFilePicker();
     }
+
     Fliplet.Widget.complete();
   });
 }


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5360

## Description
Prevent click on save button while data is saving

## Screenshots/screencasts
![click-while-save](https://user-images.githubusercontent.com/53430352/70623035-d7510400-1c25-11ea-90b8-6348d6e81bf2.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
This solution work in pair with this [PR.](https://github.com/Fliplet/fliplet-widget-image-editor/pull/21)