### PR TITLE
Fixed wide image display on the IE 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # IDE and OS files
 .DS_Store
 .idea
+.history

--- a/css/build.css
+++ b/css/build.css
@@ -4,7 +4,7 @@ img {
 }
 
 img[data-image-id] {
-  max-width: 100%;
+  max-width: 92vw;
   height: auto;
 }
 


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5392

## Description
Fixed wide image display on the IE 11

## Screenshots/screencasts
![wide-image-ie](https://user-images.githubusercontent.com/53430352/71359750-4cadc480-2596-11ea-8a9d-0546fe967364.gif)


## Backward compatibility

This change is fully backward compatible.

## Notes
Works together with this [PR](https://github.com/Fliplet/fliplet-widget-image-editor/pull/23).