### PR TITLE
Check if image or placeholder are loaded

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -5,8 +5,19 @@ function loaded() {
   Fliplet.Studio.emit('get-selected-widget');
 }
 
+function checkImageIsLoaded(id) {
+  var image = $('[data-image-id="' + id + '"]').get(0);
+
+  if (image.complete) {
+    loaded();
+  } else {
+    image.addEventListener('load', loaded);
+  }
+}
+
 function imageInstance(data) {
   if (!data.image) {
+    checkImageIsLoaded(data.id);
     return;
   }
 
@@ -69,7 +80,6 @@ function imageInstance(data) {
 
       $img.on('load', function(){
         $placeholder.fadeInImg(this);
-        loaded();
       }).on('error', function(){
         $placeholder.fadeInImg(this);
 
@@ -101,11 +111,7 @@ function imageInstance(data) {
       image.src = imageUrl;
     }
 
-    if (image.complete) {
-      loaded();
-    } else {
-      image.addEventListener('load', loaded);
-    }
+    checkImageIsLoaded(data.id);
 
     // Trigger for banners
     $('[data-image-id="' + data.id + '"]').each(function(index, img) {
@@ -136,6 +142,7 @@ $.fn.fadeInImg = function (img) {
     $(this).replaceWith(img);
     setTimeout(function () {
       $img.addClass('lazy-loaded');
+      loaded();
       setTimeout(function () {
         $img.removeClass('lazy-placeholder');
         $img.trigger('loaded.bs.banner')

--- a/js/build.js
+++ b/js/build.js
@@ -8,6 +8,10 @@ function loaded() {
 function checkImageIsLoaded(id) {
   var image = $('[data-image-id="' + id + '"]').get(0);
 
+  if (!image) {
+    return;
+  }
+
   if (image.complete) {
     loaded();
   } else {


### PR DESCRIPTION
Recent changes did not take into account that we need to report to Studio when the image is loaded and therefore broke the highlight of the placeholder when the Image component was dropped on the device frame.

The changes on this PR fixes the issue, see video below.
https://share.getcloudapp.com/z8un40dD

Issue ref: https://github.com/Fliplet/fliplet-studio/issues/5526