### PR TITLE
DEV-622 [FIX] Show error and hide save button when widget is outside LFD.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2,7 +2,22 @@
 Fliplet.Widget.findParents({ filter: { package: 'com.fliplet.dynamic-container' } }).then(function(widgets) {
   const dynamicContainer = widgets[0];
 
-  return Fliplet.DataSources.getById(dynamicContainer && dynamicContainer.dataSourceId, {
+  if (widgets.length === 0 || !dynamicContainer.dataSourceId) {
+    Fliplet.Widget.generateInterface({
+      title: 'Configure data text',
+      fields: [
+        {
+          type: 'html',
+          html: '<p style="color: #A5A5A5; font-size: 12px; font-weight: 400;">This component needs to be placed inside a Data container with selected Data source</p>'
+        }
+      ]
+    });
+
+    return Fliplet.UI.Toast('This component needs to be placed inside a Data container with selected Data source');
+  }
+
+
+  return Fliplet.DataSources.getById(dynamicContainer.dataSourceId, {
     attributes: ['columns']
   }).then((dataSource) => {
     return _.orderBy(dataSource.columns, column => column.toLowerCase());

--- a/js/interface.js
+++ b/js/interface.js
@@ -4,7 +4,7 @@ Fliplet.Widget.findParents({ filter: { package: 'com.fliplet.dynamic-container' 
 
   if (widgets.length === 0 || !dynamicContainer.dataSourceId) {
     Fliplet.Widget.generateInterface({
-      title: 'Configure data text',
+      title: 'Configure data image',
       fields: [
         {
           type: 'html',


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Image

### What does this PR do?

Show error and hide save button when widget is outside LFD.

### JIRA ticket

[DEV-622](https://weboo.atlassian.net/browse/DEV-622)

[DEV-622]: https://weboo.atlassian.net/browse/DEV-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduces a lightweight configuration interface with a clear message when the interface context is incomplete (e.g., no parent widgets or missing data source), accompanied by a toast notification.
* Bug Fixes
  * Prevents misconfiguration by validating context early and exiting gracefully instead of proceeding with an invalid setup.
  * Ensures reliable data loading by fetching the data source directly from the dynamic container’s identifier and building the interface from case-insensitively sorted columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->