### PR TITLE
Fix/DEV-622

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -55,7 +55,7 @@ Fliplet.Widget.instance({
       }
 
       if (!recordContainer && !listRepeater) {
-        return  Fliplet.UI.Toast('This component needs to be placed inside a Record or Data list component');
+        return  Fliplet.UI.Toast('This component needs to be placed inside a Data record or Data list component');
       }
 
       let ENTRY = null;

--- a/js/interface.js
+++ b/js/interface.js
@@ -31,7 +31,7 @@ Fliplet.Widget.findParents().then(async(widgets) => {
       fields: [
         {
           type: 'html',
-          html: '<p style="color: #A5A5A5; font-size: 12px; font-weight: 400;">This component needs to be placed inside a Record or Data list component</p>'
+          html: '<p style="color: #A5A5A5; font-size: 12px; font-weight: 400;">This component needs to be placed inside a Data record or Data list component</p>'
         }
       ]
     });


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Image

### What does this PR do?

Ensures Data image settings becomes unconfigurable if the component is not inserted inside Data list or Data Record.

### JIRA ticket

[DEV-622](https://weboo.atlassian.net/browse/DEV-622)

[DEV-622]: https://weboo.atlassian.net/browse/DEV-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Clarified in-app validation message when a component isn’t placed inside the required container. The toast now specifies “Data record or Data list component,” improving consistency and reducing ambiguity for users placing components outside supported contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->