### PR TITLE
DEV-938 Replace Lodash with Fliplet.Utils

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -29,7 +29,7 @@ function imageInstance(data) {
   }
 
   var canvas = this;
-  var imageUrl = _.get(data, 'image.url', 'https://placehold.it/2160x680.png?text=Image');
+  var imageUrl = Fliplet.Utils.get(data, 'image.url', 'https://placehold.it/2160x680.png?text=Image');
   var authenticate = Promise.resolve();
 
   if (Fliplet.Media.isRemoteUrl(imageUrl)) {
@@ -131,8 +131,8 @@ function imageInstance(data) {
       return;
     }
 
-    if (_.get(data, 'action.action') === 'gallery') {
-      _.forEach(_.get(data, 'action.images'), function(image) {
+    if (Fliplet.Utils.get(data, 'action.action') === 'gallery') {
+      Fliplet.Utils.forEach(Fliplet.Utils.get(data, 'action.images'), function(image) {
         image.url = Fliplet.Media.authenticate(image.url);
       });
     }

--- a/widget.json
+++ b/widget.json
@@ -19,7 +19,7 @@
     ]
   },
   "build": {
-    "dependencies": ["fliplet-core", "font-awesome", "photoswipe"],
+    "dependencies": ["fliplet-core", "font-awesome", "photoswipe", "fliplet-utils"],
     "assets": ["js/build.js", "css/build.css"]
   },
   "references": ["action.page:page", "image.id:mediaFile"]


### PR DESCRIPTION
## Summary
- Replaced `_.get` and `_.forEach` Lodash calls with `Fliplet.Utils.get` and `Fliplet.Utils.forEach` in `js/build.js`
- Added `fliplet-utils` to build dependencies in `widget.json`

## Test plan
- [ ] Verify image widget loads correctly with the Fliplet.Utils dependency
- [ ] Verify image URL resolution works (Fliplet.Utils.get replacing _.get)
- [ ] Verify gallery action images are authenticated correctly (Fliplet.Utils.forEach replacing _.forEach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)