### PR TITLE
fix [PS-1798] remove lodash from widget

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -29,7 +29,7 @@ function imageInstance(data) {
   }
 
   var canvas = this;
-  var imageUrl = _.get(data, 'image.url', 'https://placehold.it/2160x680.png?text=Image');
+  var imageUrl = Fliplet.Utils.get(data, 'image.url', 'https://placehold.it/2160x680.png?text=Image');
   var authenticate = Promise.resolve();
 
   if (Fliplet.Media.isRemoteUrl(imageUrl)) {
@@ -131,8 +131,8 @@ function imageInstance(data) {
       return;
     }
 
-    if (_.get(data, 'action.action') === 'gallery') {
-      _.forEach(_.get(data, 'action.images'), function(image) {
+    if (Fliplet.Utils.get(data, 'action.action') === 'gallery') {
+      Fliplet.Utils.forEach(Fliplet.Utils.get(data, 'action.images'), function(image) {
         image.url = Fliplet.Media.authenticate(image.url);
       });
     }

--- a/widget.json
+++ b/widget.json
@@ -19,7 +19,7 @@
     ]
   },
   "build": {
-    "dependencies": ["fliplet-core", "font-awesome", "photoswipe"],
+    "dependencies": ["fliplet-core", "font-awesome", "photoswipe", "fliplet-utils"],
     "assets": ["js/build.js", "css/build.css"]
   },
   "references": ["action.page:page", "image.id:mediaFile"]


### PR DESCRIPTION
**Product areas affected**

fliplet-widget-image

**What does this PR do?**

Ensures lodash is replaced with fliplet utils

**JIRA ticket**

[PS-1798](https://weboo.atlassian.net/browse/PS-1798)

[PS-1798]: https://weboo.atlassian.net/browse/PS-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ